### PR TITLE
test: migrate config file to TypeScript

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,6 @@
-/** @type {import('@jest/types/build/Config').InitialOptions} */
-module.exports = {
+import type { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/$1',
     '^vue$': 'vue/dist/vue.common.js'
@@ -27,3 +28,4 @@ module.exports = {
     '!**/__tests__/**'
   ]
 }
+export default config


### PR DESCRIPTION
Jest supports `jest.config.ts` configuration file since [v26.6.0](https://github.com/facebook/jest/releases/tag/v26.6.0).
This PR migrates `jest.config.js` file to TypeScript, and make this repository **all** pure TypeScript!
## Ref
- https://jestjs.io/docs/configuration